### PR TITLE
Add order config option

### DIFF
--- a/MMM-Wunderlist.js
+++ b/MMM-Wunderlist.js
@@ -11,6 +11,7 @@ Module.register("MMM-Wunderlist", {
 
  defaults: {
 	maximumEntries: 10,
+	order: "normal",
 	lists: ["inbox"],
 	interval: 60,
 	fade: true,
@@ -43,8 +44,11 @@ Module.register("MMM-Wunderlist", {
 		var list = this.tasks[this.config.lists[i]];
 
 		for (var todo in list) {
-		 tasksShown.push(list[todo]);
-
+                 if(this.config.order == "reversed"){
+                   tasksShown.push(list[todo]);
+                 } else {
+                   tasksShown.unshift(list[todo]);
+                 }
 		}
 	 }
 	}

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ The following properties can be configured:
 				<br><b>Example:</b> <code>["inbox", "ViRO Entertainment"]</code>
 			</td>
 		</tr>
+		</tr>
+		<tr>
+			<td><code>order</code></td>
+			<td>Order of tasks on the list. <br>
+				<br><b>Possible values:</b> <code>"normal"</code>, <code>"reversed"</code>
+				<br><b>Default value:</b> <code>"normal"</code>
+			</td>
+		</tr>
 		<tr>
 			<td><code>maximumEntries</code></td>
 			<td>Maximum number of todos to be shown.<br>


### PR DESCRIPTION
Change default tasks order to match Wunderlist app order and add config option, which can be set to 'reversed'.
