### PR TITLE
Fix fetcher errors

### DIFF
--- a/fetcher.js
+++ b/fetcher.js
@@ -64,7 +64,6 @@ var Fetcher = function(
 							// Wunderlist is known to occasionally have interal server-errors
 							if (isWunderlistAPIError(err) && revision != 0) {
 								console.log("Wunderlist returned an internal server-error. Recovering.")
-								scheduleTimer();
 							} else {
 								console.error(
 									"Failed to retrieve list: " +
@@ -77,6 +76,8 @@ var Fetcher = function(
 										err.stack
 								);
 							}
+
+							scheduleTimer();
 						});
 				} else {
 					scheduleTimer();
@@ -88,7 +89,6 @@ var Fetcher = function(
 				// Wunderlist is known to occasionally have interal server-errors
 				if (isWunderlistAPIError(err) && revision != 0) {
 					console.log("Wunderlist returned an internal server-error. Recovering.")
-					scheduleTimer();
 				} else {
 					console.error(
 						"Failed to retrieve status for list: " +
@@ -101,6 +101,8 @@ var Fetcher = function(
 							err.stack
 					);
 				}
+
+				scheduleTimer();
 			});
 	};
 


### PR DESCRIPTION
I noticed that sometimes the list stop updating because of some other errors which are not a 500, scheduling the timer no matter which kind of the error is thrown it's fixing it for me. I think this change might also solve some of the open issues 